### PR TITLE
Use more go-like duration types for retries

### DIFF
--- a/retry/algorithms.go
+++ b/retry/algorithms.go
@@ -13,14 +13,14 @@ type BackoffAlgorithm interface {
 
 type Exponential struct {
 	mult  float64
-	max   float64
-	start float64
+	max   time.Duration
+	start time.Duration
 }
 
 func (exp *Exponential) Backoff(iter int) time.Duration {
-	dur := algorithms.Max(exp.start*exp.mult, exp.max)
-	exp.start = dur
-	return time.Duration(exp.start)
+	dur := algorithms.Max(float64(exp.start)*exp.mult, float64(exp.max))
+	exp.start = time.Duration(dur)
+	return exp.start
 }
 
 func (exp *Exponential) Continue() bool {
@@ -33,13 +33,13 @@ func (exp *Exponential) Continue() bool {
 
 type Constant struct {
 	max   int
-	dur   int
+	dur   time.Duration
 	count int
 }
 
 func (con *Constant) Backoff(iter int) time.Duration {
 	con.count++
-	return time.Duration(con.dur)
+	return con.dur
 }
 
 func (con *Constant) Continue() bool {

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -2,11 +2,11 @@ package retry
 
 import "time"
 
-func NewExponential(start, max int64, mult float64) *Exponential {
-	return &Exponential{start: float64(start), max: float64(max), mult: mult}
+func NewExponential(start, max time.Duration, mult float64) *Exponential {
+	return &Exponential{start: start, max: max, mult: mult}
 }
 
-func NewConstant(duration, count int) *Constant {
+func NewConstant(duration time.Duration, count int) *Constant {
 	return &Constant{dur: duration, max: count}
 }
 


### PR DESCRIPTION
Makes interacting w/ the lib as a caller a bit more natural, esp with `30 * time.Milliseconds` inputs