### PR TITLE
feat: Backfill Sprig functions in Liquid templating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# IDE
+.idea

--- a/template/liquid.go
+++ b/template/liquid.go
@@ -22,7 +22,7 @@ var (
 		"sha256sum":     "sha26sum",
 	}
 
-	// internalFunctions to register. These will override Sprig functions.
+	// internalFunctions to register. These will override Sprig functions if same names are used.
 	internalFunctions = map[string]any{
 		"indent":  indent,
 		"nindent": nindent,

--- a/template/liquid.go
+++ b/template/liquid.go
@@ -1,36 +1,58 @@
 package template
 
 import (
+	"strings"
+
 	"github.com/Masterminds/sprig/v3"
 	"github.com/osteele/liquid"
 	"github.com/pluralsh/polly/algorithms"
 )
 
 var (
-	liquidEngine           = liquid.NewEngine()
+	liquidEngine = liquid.NewEngine()
+
+	// excludedSprigFunctions contains names of Spring functions that will be excluded.
 	excludedSprigFunctions = []string{"hello", "now", "uuidv4"}
-	sprigFunctionNameMap   = map[string]string{
+
+	// sprigFunctionNameAliases contains additional aliases for Sprig functions.
+	sprigFunctionNameAliases = map[string]string{
 		"toJson":        "to_json",
 		"fromJson":      "from_json",
 		"semverCompare": "semver_compare",
 		"sha256sum":     "sha26sum",
+	}
+
+	// internalFunctions to register. These will override Sprig functions.
+	internalFunctions = map[string]any{
+		"indent":  indent,
+		"nindent": nindent,
+		"replace": strings.ReplaceAll,
+		"default": dfault,
+		"ternary": ternary,
 	}
 )
 
 func init() {
 	fncs := sprig.TxtFuncMap()
 
+	excludedFunctions := excludedSprigFunctions
+	for k := range internalFunctions {
+		excludedFunctions = append(excludedFunctions, k)
+	}
+
 	for name, fnc := range fncs {
-		if algorithms.Index(excludedSprigFunctions, func(s string) bool { return s == name }) < 0 {
+		if algorithms.Index(excludedFunctions, func(s string) bool { return s == name }) < 0 {
 			liquidEngine.RegisterFilter(name, fnc)
 		}
 	}
 
-	for key, name := range sprigFunctionNameMap {
+	for key, name := range sprigFunctionNameAliases {
 		liquidEngine.RegisterFilter(name, fncs[key])
 	}
 
-	liquidEngine.RegisterFilter("ternary", ternary)
+	for name, fnc := range internalFunctions {
+		liquidEngine.RegisterFilter(name, fnc)
+	}
 }
 
 func RenderLiquid(input []byte, bindings map[string]interface{}) ([]byte, error) {

--- a/template/liquid.go
+++ b/template/liquid.go
@@ -3,11 +3,13 @@ package template
 import (
 	"github.com/Masterminds/sprig/v3"
 	"github.com/osteele/liquid"
+	"github.com/pluralsh/polly/algorithms"
 )
 
 var (
-	liquidEngine         = liquid.NewEngine()
-	sprigFunctionNameMap = map[string]string{
+	liquidEngine           = liquid.NewEngine()
+	excludedSprigFunctions = []string{"hello", "now", "uuidv4"}
+	sprigFunctionNameMap   = map[string]string{
 		"toJson":        "to_json",
 		"fromJson":      "from_json",
 		"semverCompare": "semver_compare",
@@ -19,7 +21,9 @@ func init() {
 	fncs := sprig.TxtFuncMap()
 
 	for name, fnc := range fncs {
-		liquidEngine.RegisterFilter(name, fnc)
+		if algorithms.Index(excludedSprigFunctions, func(s string) bool { return s == name }) < 0 {
+			liquidEngine.RegisterFilter(name, fnc)
+		}
 	}
 
 	for key, name := range sprigFunctionNameMap {

--- a/template/liquid.go
+++ b/template/liquid.go
@@ -1,38 +1,31 @@
 package template
 
 import (
-	"strings"
-
 	"github.com/Masterminds/sprig/v3"
 	"github.com/osteele/liquid"
 )
 
 var (
-	liquidEngine   = liquid.NewEngine()
-	sprigFunctions = map[string]string{
+	liquidEngine         = liquid.NewEngine()
+	sprigFunctionNameMap = map[string]string{
 		"toJson":        "to_json",
 		"fromJson":      "from_json",
-		"b64enc":        "b64enc",
-		"b64dec":        "b64dec",
 		"semverCompare": "semver_compare",
 		"sha256sum":     "sha26sum",
-		"quote":         "quote",
-		"squote":        "squote",
-		"replace":       "replace",
-		"coalesce":      "coalesce",
 	}
 )
 
 func init() {
 	fncs := sprig.TxtFuncMap()
-	for key, name := range sprigFunctions {
+
+	for name, fnc := range fncs {
+		liquidEngine.RegisterFilter(name, fnc)
+	}
+
+	for key, name := range sprigFunctionNameMap {
 		liquidEngine.RegisterFilter(name, fncs[key])
 	}
-	liquidEngine.RegisterFilter("indent", indent)
-	liquidEngine.RegisterFilter("nindent", nindent)
-	liquidEngine.RegisterFilter("replace", strings.ReplaceAll)
 
-	liquidEngine.RegisterFilter("default", dfault)
 	liquidEngine.RegisterFilter("ternary", ternary)
 }
 

--- a/template/liquid.go
+++ b/template/liquid.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/Masterminds/sprig/v3"
 	"github.com/osteele/liquid"
-	"github.com/pluralsh/polly/algorithms"
+	"github.com/samber/lo"
 )
 
 var (
@@ -41,7 +41,7 @@ func init() {
 	}
 
 	for name, fnc := range fncs {
-		if algorithms.Index(excludedFunctions, func(s string) bool { return s == name }) < 0 {
+		if !lo.Contains(excludedFunctions, name) {
 			liquidEngine.RegisterFilter(name, fnc)
 		}
 	}

--- a/template/utils.go
+++ b/template/utils.go
@@ -1,9 +1,58 @@
 package template
 
+import (
+	"reflect"
+	"strings"
+)
+
+func indent(v string, spaces int) string {
+	pad := strings.Repeat(" ", spaces)
+	return pad + strings.ReplaceAll(v, "\n", "\n"+pad)
+}
+
+func nindent(v string, spaces int) string {
+	return "\n" + indent(v, spaces)
+}
+
 func ternary(v bool, vt interface{}, vf interface{}) interface{} {
 	if v {
 		return vt
 	}
 
 	return vf
+}
+
+func dfault(v1, v2 interface{}) interface{} {
+	if empty(v1) {
+		return v2
+	}
+
+	return v1
+}
+
+func empty(given interface{}) bool {
+	g := reflect.ValueOf(given)
+	if !g.IsValid() {
+		return true
+	}
+
+	// Basically adapted from text/template.isTrue
+	switch g.Kind() {
+	default:
+		return g.IsNil()
+	case reflect.Array, reflect.Slice, reflect.Map, reflect.String:
+		return g.Len() == 0
+	case reflect.Bool:
+		return !g.Bool()
+	case reflect.Complex64, reflect.Complex128:
+		return g.Complex() == 0
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return g.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return g.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return g.Float() == 0
+	case reflect.Struct:
+		return false
+	}
 }

--- a/template/utils.go
+++ b/template/utils.go
@@ -1,58 +1,9 @@
 package template
 
-import (
-	"reflect"
-	"strings"
-)
-
-func indent(v string, spaces int) string {
-	pad := strings.Repeat(" ", spaces)
-	return pad + strings.ReplaceAll(v, "\n", "\n"+pad)
-}
-
-func nindent(v string, spaces int) string {
-	return "\n" + indent(v, spaces)
-}
-
 func ternary(v bool, vt interface{}, vf interface{}) interface{} {
 	if v {
 		return vt
 	}
 
 	return vf
-}
-
-func dfault(v1, v2 interface{}) interface{} {
-	if empty(v1) {
-		return v2
-	}
-
-	return v1
-}
-
-func empty(given interface{}) bool {
-	g := reflect.ValueOf(given)
-	if !g.IsValid() {
-		return true
-	}
-
-	// Basically adapted from text/template.isTrue
-	switch g.Kind() {
-	default:
-		return g.IsNil()
-	case reflect.Array, reflect.Slice, reflect.Map, reflect.String:
-		return g.Len() == 0
-	case reflect.Bool:
-		return !g.Bool()
-	case reflect.Complex64, reflect.Complex128:
-		return g.Complex() == 0
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return g.Int() == 0
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
-		return g.Uint() == 0
-	case reflect.Float32, reflect.Float64:
-		return g.Float() == 0
-	case reflect.Struct:
-		return false
-	}
 }


### PR DESCRIPTION
Use whole set of Sprig functions and keep old name mappings for backwards compatibility.