### PR TITLE
fix(liquid): exclude sprig append function and test for exclusion from sprig

### DIFF
--- a/docs/liquid-filters.md
+++ b/docs/liquid-filters.md
@@ -180,25 +180,6 @@ _Parameters_:
 
 _Implementation_: `github.com/Masterminds/sprig/v3.any`
 
-##  `append`
-Appends a new item to existing list, creating a new list.
-
-
-_Parameters_:
-
-- List
-
-- Item to append
-
-
-
-
-_Example_: `append ( list 1 2 3 ) 5` returns `[1, 2, 3, 5]`.
-
-
-
-_Implementation_: `github.com/Masterminds/sprig/v3.push`
-
 ##  `atoi`
 Converts a string to an integer.
 

--- a/template/liquid.go
+++ b/template/liquid.go
@@ -39,6 +39,7 @@ var (
 		"downcase",
 		"upcase",
 		"replace",
+		"append",
 	}
 
 	// sprigFunctionNameAliases contains additional aliases for Sprig functions.

--- a/template/liquid_test.go
+++ b/template/liquid_test.go
@@ -1,0 +1,28 @@
+package template_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pluralsh/polly/template"
+)
+
+func TestAppendFunctionNotOverridden(t *testing.T) {
+	// Test data
+	input := `{% assign fruits = "apple" | append: ", banana" %}{{ fruits }}`
+	expected := "apple, banana"
+
+	// Render the template
+	result, err := template.RenderLiquid([]byte(input), map[string]interface{}{})
+
+	// Assert that rendering was successful and produced the expected output
+	assert.NoError(t, err)
+	assert.Equal(t, expected, string(result))
+
+	// Additionally, verify that the function wasn't registered from Sprig
+	// by checking if it's in the excluded functions list
+	filters := template.RegisteredFilters()
+	_, exists := filters["append"]
+	assert.True(t, !exists, "append function should not be registered as it is excluded from Sprig functions")
+}


### PR DESCRIPTION
This should fix issue with sprig append function being used for append causing panics since it works on lists instead of strings.