### PR TITLE
fix: remove weakly typed input from lua setup

### DIFF
--- a/luautils/test/lua_example_test.go
+++ b/luautils/test/lua_example_test.go
@@ -430,3 +430,29 @@ func TestJSONSchema(t *testing.T) {
 	assert.NoError(t, err)
 
 }
+
+func TestBoolAssignments(t *testing.T) {
+	luaScript := `
+		values = {}
+		valuesFiles = {}
+		values["a"] = true
+		values["b"] = false
+		values["c"] = "false" -- string
+		values["d"] = "true" -- string
+	`
+
+	// Directory setup
+	dir, err := os.Getwd()
+	assert.NoError(t, err)
+
+	fullPath := filepath.Join(dir, "files")
+
+	// Process the Lua script; capture returned values
+	p := NewTestProcessor(fullPath)
+	values, _, err := p.Process(luaScript)
+	assert.NoError(t, err)
+	assert.Equal(t, true, values["a"])
+	assert.Equal(t, false, values["b"])
+	assert.Equal(t, "false", values["c"])
+	assert.Equal(t, "true", values["d"])
+}


### PR DESCRIPTION
 Gracefully handle Lua-to-Go type mismatches by setting the destination (st) to its zero value instead of returning an error.
Previously, the Map function returned an error when the Lua table type didn't match the expected Go struct/slice/map type after removing weakly typed input from the Lua setup. This change ensures that st is reset to a clean zero value in such cases, allowing the application to continue safely without panics or inconsistent state.